### PR TITLE
Add export command for Processing sketches

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
 				"command": "processing.sketch.new",
 				"title": "Create a new Processing Sketch",
 				"icon": "$(new-file)"
+			},
+			{
+				"command": "processing.sketch.export",
+				"title": "Export the Processing Sketch"
 			}
 		],
 		"keybindings": [


### PR DESCRIPTION
Introduces a new 'processing.sketch.export' command that runs the sketch with the '--export' argument. Updates the command registration and package.json to include the export functionality in the command palette.